### PR TITLE
Fixes issue with _meta failing type checks.

### DIFF
--- a/lib/Badge/Depot/Plugin/Travis.pm
+++ b/lib/Badge/Depot/Plugin/Travis.pm
@@ -50,15 +50,15 @@ has _meta => (
 sub _build_meta {
     my $self = shift;
 
-    return if !path('META.json')->exists;
+    return {} if !path('META.json')->exists;
 
     my $json = path('META.json')->slurp_utf8;
     my $data = decode_json($json);
 
-    return if !exists $data->{'resources'}{'repository'}{'web'};
+    return {} if !exists $data->{'resources'}{'repository'}{'web'};
 
     my $repository = $data->{'resources'}{'repository'}{'web'};
-    return if $repository !~ m{^https://(?:www\.)?github\.com/([^/]+)/(.*)(?:\.git)?$};
+    return {} if $repository !~ m{^https://(?:www\.)?github\.com/([^/]+)/(.*)(?:\.git)?$};
 
     return {
         username => $1,


### PR DESCRIPTION
Thanks for this module. Here is a little fix from me for a corner case that occurs when META.json is not present.

return {} instead of undefined in _build_meta.
This prevents failure of type check for HashRef on _meta.
